### PR TITLE
Fix versioning constraints

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,11 +31,11 @@ jobs:
     
     - run: echo ${{ matrix.python-version }} >> .python-version
 
-    - name: Install rye
-      uses: eifinger/setup-rye@v4
+    - name: Install uv
+      uses: astral-sh/setup-uv@v5
 
     - name: Install dependencies
-      run: rye sync
+      run: uv sync --extra dev
 
     - name: Test linux
       if: runner.os == 'Linux'
@@ -46,7 +46,7 @@ jobs:
         command: |
           sudo apt-get install -y xvfb xserver-xephyr scrot gnome-screenshot
           mkdir -p screenshots
-          xvfb-run -a rye test -v
+          xvfb-run -a uv run pytest -v
 
     - name: Test windows
       if: runner.os == 'Windows'
@@ -56,7 +56,7 @@ jobs:
         max_attempts: 3
         command: |
           mkdir -p screenshots
-          rye test -v
+          uv run pytest -v
 
     - name: Test mac [1]
       if: runner.os == 'macOS'
@@ -79,13 +79,13 @@ jobs:
           mkdir -p screenshots
           Xvfb :1 & 
           export DISPLAY=":1"
-          rye test -v
+          uv run pytest -v
 
     - name: Upload screenshots
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       if: always()
       with:
-        name: screenshots
+        name: screenshots-${{ matrix.os }}-${{ matrix.python-version }}
         path: screenshots/*.png
 
     # - name: Setup tmate session

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,15 +1,15 @@
 [project]
 name = "can-explorer"
-version = "0.2.1"
+version = "0.2.2"
 description = "Visualize CAN bus payloads in real time"
 authors = [
     { name = "TJ", email = "tbruno25@gmail.com" }
 ]
 dependencies = [
     "pyserial>=3.5",
-    "python-can>=4.4.2",
-    "dearpygui>=1.11.1",
-    "dearpygui-ext>=0.9.5",
+    "python-can>=4.0.0",
+    "dearpygui>=1.9.0, <2.0.0",
+    "dearpygui-ext>=0.9.0, <2.0.0",
 ]
 readme = "README.md"
 requires-python = ">= 3.10"
@@ -33,9 +33,8 @@ can-explorer = "can_explorer.__main__:__main__"
 requires = ["hatchling"]
 build-backend = "hatchling.build"
 
-[tool.rye]
-managed = true
-dev-dependencies = [
+[project.optional-dependencies]
+dev = [
     "pytest>=8.3.2",
     "pytest-dpg>=0.1.5",
     "msvc-runtime ; platform_system == 'Windows'",


### PR DESCRIPTION
Changes
- loosen versioning constraints 
- use `uv` instead of deprecated `rye`
- fix ci tests